### PR TITLE
Add RetosSwap and DawnSwap as Haveno network instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Some platforms require the use of a phone number which are typically tied to per
 Note: An Altcoin-only exchange means bitcoin is not one of the trading currencies. There may be offers though where Bitcoin is one of the payment methods available though.
 
 - [Haveno DEX](https://github.com/haveno-dex/haveno/blob/master/README.md) client (💵) [**NO KYC**]← Fully decentralized and non-custodial. Uses Tor, automatically. [FAQ](https://github.com/haveno-dex/haveno/wiki/FAQ)
+  - [RetosSwap](https://retoswap.com) [**NO KYC**] <-- Haveno network instance. $2M+/month volume. 15% security deposits, 0.6% fees. Arbitrator: RoundTheRoses (24-48h response). Largest Haveno network.
+  - [DawnSwap](https://dawnswap.com) [**NO KYC**] <-- Haveno network instance. 5% security deposits, ~2% fees. 24/7 arbitration (faster than RetosSwap). Growing network, lower capital requirements.
 - [ByBit P2P](https://www.bybit.com/fiat/trade/otc) <-- USDT only, initially. Not available in the U.S.
 - [Benkiko](https://www.benkiko.io) <-- USDB only, initially
 - [Timbuktu](https://timbuktu.exchange) [**NO KYC** (for offer taker)]


### PR DESCRIPTION
The current Haveno DEX entry links only to the base code repository. Haveno itself is a protocol — actual trading happens on network instances (similar to how Bisq has its own network).

This PR adds the two major running Haveno network instances:

- **RetosSwap** — The largest Haveno network with $2M+/month trading volume, 15% security deposits, and established arbitration (RoundTheRoses).
- **DawnSwap** — A newer network offering lower security deposits (5%), ~2% fees, and 24/7 arbitration. Growing user base.

Both are fully non-custodial, NO KYC, and use Tor automatically. They support Cash by Mail, Face-to-Face, bank transfer, and other payment methods for P2P cryptocurrency trading.

This is analogous to how the list includes both Bisq (the project) and its active network.